### PR TITLE
0.3.2

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['24.x']
+        node-version: ['24.4']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['24.x']
+        node-version: ['24.4']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.2] - 2025-07-27
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- update @iori/core to 0.3.3
+- Update @iori/core to 0.3.3
 - Updated Node.js version to 24.4 in CI workflows for improved compatibility and latest features
 - Enhanced CI/CD stability with specific Node.js version pinning instead of using version ranges
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Updated Node.js version to 24.4 in CI workflows for improved compatibility and latest features
+- Enhanced CI/CD stability with specific Node.js version pinning instead of using version ranges
+
+### Technical
+
+- Modified GitHub Actions workflows (development.yml and release.yml) to use Node.js 24.4 specifically
+- Improved build consistency by removing version range specification ('24.x' → '24.4')
+
 ## [0.3.1] - 2025-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- update @iori/core to 0.3.3
 - Updated Node.js version to 24.4 in CI workflows for improved compatibility and latest features
 - Enhanced CI/CD stability with specific Node.js version pinning instead of using version ranges
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@ioris/core": "^0.3.2",
+        "@ioris/core": "^0.3.3",
         "kuromoji": "^0.1.2"
       },
       "devDependencies": {
@@ -796,9 +796,9 @@
       }
     },
     "node_modules/@ioris/core": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@ioris/core/-/core-0.3.2.tgz",
-      "integrity": "sha512-5ek8pOOZJTMwBbmqF1f49xEbdFjqXh8v5tneV3Mligj/kxvtnHkGydK6PwzPweIoTqYJqM5dkh3ibMK5g7R6Nw==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@ioris/core/-/core-0.3.3.tgz",
+      "integrity": "sha512-BdS/1fGhMbTdRNpf2M7V9um60bdwyDw6OOn+j3vSQsfM3bUEo07NUbH9YlA4eyVGUel358oCBdX2q1DO9PQMYA==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ioris/tokenizer-kuromoji",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ioris/tokenizer-kuromoji",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@ioris/core": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "@ioris/core": "^0.3.2",
+    "@ioris/core": "^0.3.3",
     "kuromoji": "^0.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ioris/tokenizer-kuromoji",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "",
   "type": "module",
   "main": "dist/index.mjs",


### PR DESCRIPTION
## [0.3.2] - 2025-07-27

### Changed

- update @iori/core to 0.3.3
- Updated Node.js version to 24.4 in CI workflows for improved compatibility and latest features
- Enhanced CI/CD stability with specific Node.js version pinning instead of using version ranges

### Technical

- Modified GitHub Actions workflows (development.yml and release.yml) to use Node.js 24.4 specifically
- Improved build consistency by removing version range specification ('24.x' → '24.4')